### PR TITLE
update org.example:upstream to 0.0.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
 		<dependency>
 			<groupId>org.example</groupId>
 			<artifactId>upstream</artifactId>
-			<version>0.0.2</version>
+			<version>0.0.7</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
[UpdateBot](https://github.com/jenkins-x/updatebot) pushed maven dependency: `org.example:upstream` to: `0.0.5`